### PR TITLE
Elements equal

### DIFF
--- a/lib/elements.js
+++ b/lib/elements.js
@@ -29,7 +29,7 @@ define(function () {
                 num = 0;
             }
 
-            new Assertion(exp, msg).to.have.length.equal(num || 0);
+            new Assertion(exp, msg).to.have.length(num || 0);
         });
         assert.elementsEqual = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsEqual(num, msg);

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -34,8 +34,21 @@ define(function () {
         assert.elementsEqual = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsEqual(num, msg);
         };
+
+
+        Assertion.addMethod('elementsNotEqual', function (num, msg) {
+            var exp = this._obj;
+            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+
+            if (typeof num === 'string') {
+                msg = num;
+                num = 0;
+            }
+
+            new Assertion(exp, msg).to.not.have.length(num || 0);
+        });        
         assert.elementsNotEqual = function (exp, num, msg) {
-            new Assertion(exp).to.not.have.elementsEqual(num, msg);
+            new Assertion(exp).to.have.elementsNotEqual(num, msg);
         };
     };
 


### PR DESCRIPTION
Status: **Ready for Review**
Owner: myself
Reviewers: @vmarta @mobify-derrick 
- [ ] let @alicjaMobify know of these changes, as she's currently writing documentation for our chai assertions
## Changes
- Removes the .equal in the assertion. This was checking for strict equality, which we don't really need. Fixes an issue where `assert.elementsEqual($listing, 1);` would throw an error that `Array[1] does not equal 1`
- Adds `elementsNotEqual` in both expect and assert flavours:
  `assert.elementsNotEqual($listing, 2);` and `expect($listing).to.have.elementsNotEqual(2);`
### Feedback:

_none so far_
## How to Test
- Change your package.json:
  `"mobify-chai-assertions": "git+ssh://git@github.com:mobify/chai-custom-assertions.git#elements-equal",`
- Run npm install
- Use the above assertions
