### PR TITLE
separate elementsNotPresent assertion

### DIFF
--- a/lib/elements.js
+++ b/lib/elements.js
@@ -15,8 +15,16 @@ define(function () {
         assert.elementsPresent = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsPresent(num, msg);
         };
-        assert.elementsNotPresent = function (exp, num, msg) {
-            new Assertion(exp).to.not.have.elementsPresent(num, msg);
+
+
+        Assertion.addMethod('elementsNotPresent', function (msg) {
+            var exp = this._obj;
+            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+
+            new Assertion(exp, msg).to.have.length(0);
+        });
+        assert.elementsNotPresent = function (exp, msg) {
+            new Assertion(exp).to.have.elementsNotPresent(msg);
         };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-chai-assertions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Mobify's custom assertions for Chai",
   "main": "assertions.js",
   "scripts": {


### PR DESCRIPTION
Status: **Ready for Review**
Owner: myself
Reviewers: @vmarta @mobify-derrick 
- [ ] let @alicjaMobify know of these changes, as she's currently writing documentation for our chai assertions
## Changes
- Adds a separate `elementsNotPresent` assertion that takes only the optional message and checks that there are no elements in the expression, ie. length is 0.
### Feedback:

_none so far_
## How to Test
- Change your package.json:
  `"mobify-chai-assertions": "git+ssh://git@github.com:mobify/chai-custom-assertions.git#elements-not-present",`
- Run npm install

```
        'context.listing assert elementsNotPresent': function($, context) {
            var $listing = context.listing;

            assert.elementsNotPresent($listing, 'Listing should not be present');
        },

        'context.listing expect elementsNotPresent': function($, context) {
            var $listing = context.listing;

            expect($listing).to.have.elementsNotPresent();
        }
```
