### PR TITLE
Chai Assertions Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ https://www.npmjs.com/package/mobify-chai-assertions
 
 ## How To Use the Plugin
 
-To use the plugin is simply calling Chai's `use()` function:
+To use the plugin, simply call Chai's `use()` function:
 
 ```javascript
 var chai = require('node_modules/chai/chai');
@@ -18,15 +18,15 @@ chai.use(customAssertions);
 
 ## New Assertion Methods
 
-The plugin extends Chai by adding the following methods. Feel free to use either the `assert` or `expect` styles.
+The plugin extends Chai by adding the following methods. Feel free to use either the `assert` or `expect` styles. They work with any of the chains listed in the [Chai API documentation](http://chaijs.com/api/bdd/).
 
 (Note: since Chai's API supports only the `expect` style, we implemented these methods for the `expect` style first and then the `assert` style as a wrapper)
 
 ### Elements
 
-All of these commands can take an optional `msg` parameter to output a custom error message on test failure. 
+All of these assertions can take an optional `msg` parameter to output a custom error message on test failure. 
 
-[] syntax denotes an optional parameter. 
+[ ] syntax denotes an optional parameter. 
 
 `elements([msg])`
 
@@ -52,7 +52,7 @@ expect($paymentOptions).to.be.present;
 var items = [1, 2, 3];
 expect(items).to.be.present;
 expect(items).to.be.present(3);
-expect(items).to.be.present(3, 'my custom failure message');
+expect(items).to.be.present(4, 'my custom failure message');
 
 // Can be used in a chain:
 // Zepto/jQuery object has length at least 1
@@ -68,14 +68,15 @@ expect($paymentOptions).to.have.elements.not.present;
 ```javascript
 // Asserts that it has a specified length
 var items = [1, 2, 3];
-expect(items).to.have.count(3, 'my custom failure message');
+expect(items).to.have.count(3);
+expect(items).to.have.count(5, 'my custom failure message');
 
 // Asserts that a jQuery/Zepto object has a specified length
 var $images = $('img');
 expect($images).to.have.elements.count(24);
 ```
 
-**Deprecated** `elementsPresent`, `elementsNotPresent`:
+**Deprecated** `elementsPresent`, `elementsNotPresent` use `elements.present` and `elements.not.present` instead:
 
 ```javascript
 // Asserts that there exists such element on page
@@ -91,7 +92,7 @@ assert.elementsNotPresent($emailForm)
 expect($emailForm).to.not.have.elementsPresent()
 ```
 
-**Deprecated** `elementsEqual`, `elementsNotEqual`:
+**Deprecated** `elementsEqual`, `elementsNotEqual` use `elements.count` instead:
 
 ```javascript
 // Asserts that there are exactly 3 of such elements
@@ -127,7 +128,7 @@ expect(lists).to.have.items;
 expect(lists).to.have.items('my custom failure message');
 ```
 
-**Deprecated** `hasItems`
+**Deprecated** `hasItems` use `have.items` instead:
 
 ```javascript
 // Asserts that this collection (e.g. an array) has at least 1 item in it

--- a/README.md
+++ b/README.md
@@ -24,9 +24,34 @@ The plugin extends Chai by adding the following methods. Feel free to use either
 
 ### Elements
 
-Works with Zepto/jQuery elements.
+`elements`
 
-`elementsPresent`, `elementsNotPresent`:
+```javascript
+// Asserts that it is a Zepto/jQuery element.
+expect($paymentOptions).to.be.elements;
+
+//Can be chained with .present and .count (see below)
+```
+
+`present`
+
+```javascript
+// Asserts that the length is greater than 0.
+// Can be used with all types of expressions.
+expect($paymentOptions).to.be.present;
+
+var items = [1, 2, 3];
+expect(items).to.be.present;
+
+// Can be used in a chain:
+// Zepto/jQuery object has length greater than 0
+expect($paymentOptions).to.have.elements.present;
+
+// Can be negated
+expect($paymentOptions).to.have.elements.not.present;
+```
+
+**Deprecated** `elementsPresent`, `elementsNotPresent`:
 
 ```javascript
 // Asserts that there exists such element on page
@@ -42,7 +67,7 @@ assert.elementsNotPresent($emailForm)
 expect($emailForm).to.not.have.elementsPresent()
 ```
 
-`elementsEqual`, `elementsNotEqual`:
+**Deprecated** `elementsEqual`, `elementsNotEqual`:
 
 ```javascript
 // Asserts that there are exactly 3 of such elements
@@ -73,8 +98,3 @@ Works with a collection of things.
 assert.hasItems(lists)
 expect(lists).to.not.be.empty
 ```
-
-
-## Future Improvements
-
-In the future, if we decide to switch to writing our tests in the `expect` style, I feel it's better if we implement better `expect` methods than what we have now. I wrote some todo in the code to show a sample of what that might look like.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 For our integration testing, we have made our own Chai's custom assertions. This is where we define, collect, and present them in a plugin form.
 
+https://www.npmjs.com/package/mobify-chai-assertions
+
 
 ## How To Use the Plugin
 

--- a/README.md
+++ b/README.md
@@ -36,19 +36,34 @@ expect($paymentOptions).to.be.elements;
 `present`
 
 ```javascript
-// Asserts that the length is greater than 0.
+// Asserts that the length is at least (>=) than num.
+// Default is 1. 
 // Can be used with all types of expressions.
 expect($paymentOptions).to.be.present;
 
 var items = [1, 2, 3];
 expect(items).to.be.present;
+expect(items).to.be.present(3);
 
 // Can be used in a chain:
-// Zepto/jQuery object has length greater than 0
+// Zepto/jQuery object has length at least 1
 expect($paymentOptions).to.have.elements.present;
 
 // Can be negated
+// Length is 0
 expect($paymentOptions).to.have.elements.not.present;
+```
+
+`count`
+
+```javascript
+// Asserts that it has a specified length
+var items = [1, 2, 3];
+expect(items).to.have.count(3);
+
+// Asserts that a jQuery/Zepto object has a specified length
+var $images = $('img');
+expect($images).to.have.elements.count(24);
 ```
 
 **Deprecated** `elementsPresent`, `elementsNotPresent`:
@@ -89,9 +104,18 @@ assert.properties(apps, 'apple', 'google')
 expect(apps).to.have.properties('apple', 'google')
 ```
 
-### Has Items
+### Items
 
 Works with a collection of things.
+
+`items`
+
+```javascript
+// Asserts that this collection (e.g. an array) has at least 1 item in it
+expect(lists).to.have.items;
+```
+
+**Deprecated** `hasItems`
 
 ```javascript
 // Asserts that this collection (e.g. an array) has at least 1 item in it

--- a/README.md
+++ b/README.md
@@ -24,16 +24,24 @@ The plugin extends Chai by adding the following methods. Feel free to use either
 
 ### Elements
 
-`elements`
+All of these commands can take an optional `msg` parameter to output a custom error message on test failure. 
+
+[] syntax denotes an optional parameter. 
+
+`elements([msg])`
 
 ```javascript
 // Asserts that it is a Zepto/jQuery element.
 expect($paymentOptions).to.be.elements;
 
+// Takes an optional error message that is displayed on failure.
+// Default error message is "Must be a Zepto/jQuery object"
+expect($paymentOptions).to.be.elements('failure: it is not a Zepto/jQuery object');
+
 //Can be chained with .present and .count (see below)
 ```
 
-`present`
+`present([num], [msg])`
 
 ```javascript
 // Asserts that the length is at least (>=) than num.
@@ -44,6 +52,7 @@ expect($paymentOptions).to.be.present;
 var items = [1, 2, 3];
 expect(items).to.be.present;
 expect(items).to.be.present(3);
+expect(items).to.be.present(3, 'my custom failure message');
 
 // Can be used in a chain:
 // Zepto/jQuery object has length at least 1
@@ -54,12 +63,12 @@ expect($paymentOptions).to.have.elements.present;
 expect($paymentOptions).to.have.elements.not.present;
 ```
 
-`count`
+`count(num, [msg])`
 
 ```javascript
 // Asserts that it has a specified length
 var items = [1, 2, 3];
-expect(items).to.have.count(3);
+expect(items).to.have.count(3, 'my custom failure message');
 
 // Asserts that a jQuery/Zepto object has a specified length
 var $images = $('img');
@@ -98,6 +107,8 @@ expect($images).to.not.have.elementsEqual(3)
 
 Works with javascript objects.
 
+`properties`
+
 ```javascript
 // Asserts that this object has the keys 'apple' and 'google'
 assert.properties(apps, 'apple', 'google')
@@ -108,11 +119,12 @@ expect(apps).to.have.properties('apple', 'google')
 
 Works with a collection of things.
 
-`items`
+`items([msg])`
 
 ```javascript
 // Asserts that this collection (e.g. an array) has at least 1 item in it
 expect(lists).to.have.items;
+expect(lists).to.have.items('my custom failure message');
 ```
 
 **Deprecated** `hasItems`

--- a/assertions.js
+++ b/assertions.js
@@ -5,7 +5,7 @@ define(function (require) {
         var Assertion    = chai.Assertion;
 
         // Add our assertions
-        require('./lib/elements')(assert, Assertion);
+        require('./lib/elements')(assert, Assertion, utils);
         require('./lib/properties')(assert, Assertion);
         require('./lib/has-items')(assert, Assertion);
     };

--- a/assertions.js
+++ b/assertions.js
@@ -11,8 +11,6 @@ define(function (require) {
     };
 
     // TODO: implement better 'expect' style
-    // expect(foo).to.have.elements.present
-    // expect(foo).to.not.have.elements.present
     // expect(foo).to.have.elements.with.length
     // expect(foo).to.have.elements.not.with.length
     // expect(foo).to.have.properties

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,11 +1,6 @@
 define(function () {
 
-    return function (assert, Assertion) {
-
-        Assertion.addChainableMethod('foo', function (str) {
-          var obj = this._obj;
-          new Assertion(obj).to.be.equal(str);
-        });
+    return function (assert, Assertion, utils) {
 
         Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -3,16 +3,19 @@ define(function () {
     return function (assert, Assertion) {
         Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;
-            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
 
-            if (typeof num === 'string') {
-                msg = num;
-                num = 0;
+            if (!msg) {
+                msg = 'Must be a Zepto/jQuery object';
             }
+            new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
+        }, function (msg) {
+            var exp = this._obj;
 
-            new Assertion(exp, msg).to.have.length.above(num || 0);
+            if (!msg) {
+                msg = 'Must be a Zepto/jQuery object';
+            }
+            new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
         });
-
 
         Assertion.addMethod('present', function (num, msg) {
             var exp = this._obj;

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -17,7 +17,9 @@ define(function () {
         }, function (msg) {
             utils.flag(this, 'elements', true);
         });
-
+        assert.elements = function (exp, msg) {
+            new Assertion(exp).to.be.elements(msg);
+        };
 
         /*
             .present checks for length greater than 0
@@ -39,8 +41,10 @@ define(function () {
             }
 
             new Assertion(exp, msg).to.have.length.above(num || 0);
-
         });
+        assert.present = function (exp, num, msg) {
+            new Assertion(exp).to.be.present(num, msg);
+        };
 
         /*
             .elementsPresent checks that the given Zepto/jQuery object
@@ -54,9 +58,6 @@ define(function () {
             new Assertion(exp).to.be.present(num, msg);
         });
         assert.elementsPresent = function (exp, num, msg) {
-            new Assertion(exp).to.be.present(num, msg);
-        };
-        assert.present = function (exp, num, msg) {
             new Assertion(exp).to.be.present(num, msg);
         };
 
@@ -90,6 +91,9 @@ define(function () {
 
             new Assertion(exp, msg).to.have.length(num || 0);
         });
+        assert.elementsEqual = function(exp, num, msg) {
+            new Assertion(exp).to.have.elementsEqual(num, msg);
+        };
 
         /*
             .elementsCount checks that the given jQuery/Zepto object
@@ -124,8 +128,10 @@ define(function () {
             }
 
             new Assertion(exp, msg).to.have.length(num);
-
         });
+        assert.count = function (exp, num, msg) {
+            new Assertion(exp).to.have.count(num, msg);
+        };
 
 
         Assertion.addMethod('elementsNotEqual', function (num, msg) {

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,7 +1,7 @@
 define(function () {
 
     return function (assert, Assertion) {
-        Assertion.addMethod('elementsPresent', function (num, msg) {
+        Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
 
@@ -12,8 +12,29 @@ define(function () {
 
             new Assertion(exp, msg).to.have.length.above(num || 0);
         });
+
+
+        Assertion.addMethod('present', function (num, msg) {
+            var exp = this._obj;
+            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+
+            if (typeof num === 'string') {
+                msg = num;
+                num = 0;
+            }
+
+            new Assertion(exp, msg).to.have.length.above(num || 0);
+        });
+        Assertion.addMethod('elementsPresent', function (num, msg) {
+            var exp = this._obj;
+            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+            new Assertion(exp).to.have.present(num, msg);
+        });
         assert.elementsPresent = function (exp, num, msg) {
-            new Assertion(exp).to.have.elementsPresent(num, msg);
+            new Assertion(exp).to.have.present(num, msg);
+        };
+        assert.present = function (exp, num, msg) {
+            new Assertion(exp).to.have.present(num, msg);
         };
 
 
@@ -39,7 +60,13 @@ define(function () {
 
             new Assertion(exp, msg).to.have.length(num || 0);
         });
+        Assertion.addMethod('elementsCount', function (num, msg) {
+            new Assertion(exp).to.have.elementsEqual(num, msg);
+        });
         assert.elementsEqual = function (exp, num, msg) {
+            new Assertion(exp).to.have.elementsEqual(num, msg);
+        };
+        assert.elementsCount = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsEqual(num, msg);
         };
 

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,12 +1,19 @@
 define(function () {
 
     return function (assert, Assertion) {
+
+        Assertion.addChainableMethod('foo', function (str) {
+          var obj = this._obj;
+          new Assertion(obj).to.be.equal(str);
+        });
+
         Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;
 
             if (!msg) {
                 msg = 'Must be a Zepto/jQuery object';
             }
+
             new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
         }, function (msg) {
             var exp = this._obj;
@@ -19,7 +26,6 @@ define(function () {
 
         Assertion.addMethod('present', function (num, msg) {
             var exp = this._obj;
-            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
 
             if (typeof num === 'string') {
                 msg = num;
@@ -64,6 +70,8 @@ define(function () {
             new Assertion(exp, msg).to.have.length(num || 0);
         });
         Assertion.addMethod('elementsCount', function (num, msg) {
+            var exp = this._obj;
+            if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
             new Assertion(exp).to.have.elementsEqual(num, msg);
         });
         assert.elementsEqual = function (exp, num, msg) {

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,7 +1,7 @@
 define(function () {
 
     return function (assert, Assertion, utils) {
-
+        
         Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;
 
@@ -11,13 +11,9 @@ define(function () {
 
             new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
         }, function (msg) {
-            var exp = this._obj;
-
-            if (!msg) {
-                msg = 'Must be a Zepto/jQuery object';
-            }
-            new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
+            utils.flag(this, 'elements', true);
         });
+
 
         Assertion.addMethod('present', function (num, msg) {
             var exp = this._obj;
@@ -27,8 +23,18 @@ define(function () {
                 num = 0;
             }
 
+            if (utils.flag(this, 'elements')) {
+                if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+            }
+            if (utils.flag(this, 'negate')) {
+                new Assertion(exp, msg).to.not.have.length.above(num || 0);
+            }
+
             new Assertion(exp, msg).to.have.length.above(num || 0);
+
         });
+
+
         Assertion.addMethod('elementsPresent', function (num, msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
@@ -64,6 +70,8 @@ define(function () {
 
             new Assertion(exp, msg).to.have.length(num || 0);
         });
+
+
         Assertion.addMethod('elementsCount', function (num, msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -22,7 +22,7 @@ define(function () {
         };
 
         /*
-            .present checks for length greater than 0
+            .present checks for length at least 1
             Works for all types of expressions. 
         */
         Assertion.addMethod('present', function (num, msg) {
@@ -37,10 +37,10 @@ define(function () {
                 if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
             }
             if (utils.flag(this, 'negate')) {
-                new Assertion(exp, msg).to.not.have.length.above(num || 0);
+                new Assertion(exp, msg).to.not.have.length.at.least(num || 1);
             }
 
-            new Assertion(exp, msg).to.have.length.above(num || 0);
+            new Assertion(exp, msg).to.have.length.at.least(num || 1);
         });
         assert.present = function (exp, num, msg) {
             new Assertion(exp).to.be.present(num, msg);
@@ -48,7 +48,7 @@ define(function () {
 
         /*
             .elementsPresent checks that the given Zepto/jQuery object
-            has a length greater than 0. 
+            has a length at least 1. 
             .elementsPresent is here for backwards compatibility.
             Use elements.present instead. 
         */
@@ -89,7 +89,7 @@ define(function () {
                 num = 0;
             }
 
-            new Assertion(exp, msg).to.have.length(num || 0);
+            new Assertion(exp, msg).to.have.length(num);
         });
         assert.elementsEqual = function(exp, num, msg) {
             new Assertion(exp).to.have.elementsEqual(num, msg);

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -2,6 +2,10 @@ define(function () {
 
     return function (assert, Assertion, utils) {
         
+        /*
+            .elements checks that the given expression is a Zepto/jQuery object
+            Can be chained with .present and .count
+        */ 
         Assertion.addChainableMethod('elements', function (msg) {
             var exp = this._obj;
 
@@ -15,6 +19,10 @@ define(function () {
         });
 
 
+        /*
+            .present checks for length greater than 0
+            Works for all types of expressions. 
+        */
         Assertion.addMethod('present', function (num, msg) {
             var exp = this._obj;
 
@@ -34,20 +42,30 @@ define(function () {
 
         });
 
-
+        /*
+            .elementsPresent checks that the given Zepto/jQuery object
+            has a length greater than 0. 
+            .elementsPresent is here for backwards compatibility.
+            Use elements.present instead. 
+        */
         Assertion.addMethod('elementsPresent', function (num, msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
-            new Assertion(exp).to.have.present(num, msg);
+            new Assertion(exp).to.be.present(num, msg);
         });
         assert.elementsPresent = function (exp, num, msg) {
-            new Assertion(exp).to.have.present(num, msg);
+            new Assertion(exp).to.be.present(num, msg);
         };
         assert.present = function (exp, num, msg) {
-            new Assertion(exp).to.have.present(num, msg);
+            new Assertion(exp).to.be.present(num, msg);
         };
 
-
+        /*
+            .elementsNotPresent checks that the given Zepto/jQuery object
+            has a length of 0. 
+            .elementsNotPresent is here for backwards compatibility.
+            Use elements.not.present instead. 
+        */
         Assertion.addMethod('elementsNotPresent', function (msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
@@ -60,6 +78,8 @@ define(function () {
 
 
         Assertion.addMethod('elementsEqual', function (num, msg) {
+            if (!num) throw new Error('Specify a count.');
+
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
 
@@ -71,7 +91,11 @@ define(function () {
             new Assertion(exp, msg).to.have.length(num || 0);
         });
 
-
+        /*
+            .elementsCount checks that the given jQuery/Zepto object
+            has a length of num.
+            It is better to use .elements.count. 
+        */
         Assertion.addMethod('elementsCount', function (num, msg) {
             var exp = this._obj;
             if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
@@ -83,6 +107,25 @@ define(function () {
         assert.elementsCount = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsEqual(num, msg);
         };
+
+
+        /*
+            A custom check for length.
+            When used in conjunction with .elements, expects the
+            given expression to be a Zepto/jQuery object. 
+        */
+        Assertion.addMethod('count', function (num, msg) {
+            if (!num) throw new Error('Specify a count.');
+
+            var exp = this._obj;
+
+            if (utils.flag(this, 'elements')) {
+                if (!exp.hasOwnProperty('selector')) throw new Error('exp must be a Zepto object');
+            }
+
+            new Assertion(exp, msg).to.have.length(num);
+
+        });
 
 
         Assertion.addMethod('elementsNotEqual', function (num, msg) {

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -95,6 +95,7 @@ define(function () {
             new Assertion(exp).to.have.elementsEqual(num, msg);
         };
 
+
         /*
             .elementsCount checks that the given jQuery/Zepto object
             has a length of num.

--- a/lib/has-items.js
+++ b/lib/has-items.js
@@ -1,9 +1,13 @@
 define(function () {
 
     return function (assert, Assertion) {
-        assert.hasItems = function(exp) {
-            new Assertion(exp).to.not.be.empty;
+
+        assert.hasItems = function(exp, msg) {
+            new Assertion(exp, msg).to.not.be.empty;
         };
+        assert.items = function(exp, msg) {
+        	new Assertion(exp,msg).to.hasItems;
+        }
     };
     
 });

--- a/lib/has-items.js
+++ b/lib/has-items.js
@@ -2,12 +2,14 @@ define(function () {
 
     return function (assert, Assertion) {
 
-        assert.hasItems = function(exp, msg) {
+        Assertion.addMethod('items', function (msg) {
+            var exp = this._obj;
+
             new Assertion(exp, msg).to.not.be.empty;
+        });
+        assert.hasItems = function (exp, msg) {
+            new Assertion(exp, msg).to.have.items;
         };
-        assert.items = function(exp, msg) {
-        	new Assertion(exp,msg).to.hasItems;
-        }
     };
     
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-chai-assertions",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Mobify's custom assertions for Chai",
   "main": "assertions.js",
   "scripts": {


### PR DESCRIPTION
Status: **Ready for Review**
Owner: Ellen
Reviewers: @mobify-derrick @vmarta @jgermyn @twangtina @gsaray @chrisjcook @joeycarlos @donnielrt 
## Changes
- Refactors `elementsPresent` into a chainable `elements` and `present`: `expect($contactForm).to.have.elements.present;`
- `.present` does its comparison using "at least" instead of "above" 
- Introduces chainable `.count` to assert a specific length
- Refactors `hasItems` into a method so that it can take an optional error message
- Introduces chainable `.items`: `expect(array).to.have.items`
- Previous assertions are kept for backwards compatibility
## Jira Tickets:
- https://mobify.atlassian.net/browse/CSOPS-1412
## Todos:
- [x] +1 from QA
- [ ] +1 and npm publish from @vmarta 
### Feedback:

_none so far_
## How to Test
- In `package.json`, `"mobify-chai-assertions": "git+ssh://git@github.com:mobify/chai-custom-assertions.git#revamp"`
- `npm install`
- Try using the new assertions, or see some examples https://gist.github.com/ellenmobify/3b4465f18da8c1569c8c
