### PR TITLE
'element' alias for 'elements'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ All of these assertions can take an optional `msg` parameter to output a custom 
 
 [ ] syntax denotes an optional parameter. 
 
-`elements([msg])`
+`elements([msg]) / elements([msg])`
 
 ```javascript
 // Asserts that it is a Zepto/jQuery element.
-expect($paymentOptions).to.be.elements;
+expect($paymentOptions).to.be.an.element;
 
 // Takes an optional error message that is displayed on failure.
 // Default error message is "Must be a Zepto/jQuery object"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All of these assertions can take an optional `msg` parameter to output a custom 
 
 [ ] syntax denotes an optional parameter. 
 
-`elements([msg]) / elements([msg])`
+`element([msg]) / elements([msg])`
 
 ```javascript
 // Asserts that it is a Zepto/jQuery element.

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -1,12 +1,13 @@
 define(function () {
 
     return function (assert, Assertion, utils) {
-        
+
         /*
             .elements checks that the given expression is a Zepto/jQuery object
             Can be chained with .present and .count
-        */ 
-        Assertion.addChainableMethod('elements', function (msg) {
+        */
+
+        function assertElement (msg) {
             var exp = this._obj;
 
             if (!msg) {
@@ -14,16 +15,25 @@ define(function () {
             }
 
             new Assertion(exp.hasOwnProperty('selector'), msg).to.be.true;
-        }, function (msg) {
+        }
+
+        function assertElementChain () {
             utils.flag(this, 'elements', true);
-        });
+        }
+
+        Assertion.addChainableMethod('elements', assertElement, assertElementChain);
+        Assertion.addChainableMethod('element', assertElement, assertElementChain);
+
         assert.elements = function (exp, msg) {
+            new Assertion(exp).to.be.elements(msg);
+        };
+        assert.element = function (exp, msg) {
             new Assertion(exp).to.be.elements(msg);
         };
 
         /*
             .present checks for length at least 1
-            Works for all types of expressions. 
+            Works for all types of expressions.
         */
         Assertion.addMethod('present', function (num, msg) {
             var exp = this._obj;
@@ -48,9 +58,9 @@ define(function () {
 
         /*
             .elementsPresent checks that the given Zepto/jQuery object
-            has a length at least 1. 
+            has a length at least 1.
             .elementsPresent is here for backwards compatibility.
-            Use elements.present instead. 
+            Use elements.present instead.
         */
         Assertion.addMethod('elementsPresent', function (num, msg) {
             var exp = this._obj;
@@ -63,9 +73,9 @@ define(function () {
 
         /*
             .elementsNotPresent checks that the given Zepto/jQuery object
-            has a length of 0. 
+            has a length of 0.
             .elementsNotPresent is here for backwards compatibility.
-            Use elements.not.present instead. 
+            Use elements.not.present instead.
         */
         Assertion.addMethod('elementsNotPresent', function (msg) {
             var exp = this._obj;
@@ -99,7 +109,7 @@ define(function () {
         /*
             .elementsCount checks that the given jQuery/Zepto object
             has a length of num.
-            It is better to use .elements.count. 
+            It is better to use .elements.count.
         */
         Assertion.addMethod('elementsCount', function (num, msg) {
             var exp = this._obj;
@@ -117,7 +127,7 @@ define(function () {
         /*
             A custom check for length.
             When used in conjunction with .elements, expects the
-            given expression to be a Zepto/jQuery object. 
+            given expression to be a Zepto/jQuery object.
         */
         Assertion.addMethod('count', function (num, msg) {
             if (!num) throw new Error('Specify a count.');
@@ -145,7 +155,7 @@ define(function () {
             }
 
             new Assertion(exp, msg).to.not.have.length(num || 0);
-        });        
+        });
         assert.elementsNotEqual = function (exp, num, msg) {
             new Assertion(exp).to.have.elementsNotEqual(num, msg);
         };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-chai-assertions",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Mobify's custom assertions for Chai",
   "main": "assertions.js",
   "scripts": {


### PR DESCRIPTION
Status: **Ready for Review** 
Owner: Ellen
Reviewers: 
## Changes
- Refactored `elements` method
- Adds `element` that behaves in the same way as `elements`
## Jira Tickets:
- https://mobify.atlassian.net/browse/CSOPS-1527
## Todos:
- [ ] +1
### Feedback:

_none so far_
